### PR TITLE
Avoid maybe-uninitialized warning.

### DIFF
--- a/easywsclient.cpp
+++ b/easywsclient.cpp
@@ -274,7 +274,7 @@ class _RealWebSocket : public easywsclient::WebSocket
             ws.N0 = (data[1] & 0x7f);
             ws.header_size = 2 + (ws.N0 == 126? 2 : 0) + (ws.N0 == 127? 8 : 0) + (ws.mask? 4 : 0);
             if (rxbuf.size() < ws.header_size) { return; /* Need: ws.header_size - rxbuf.size() */ }
-            int i;
+            int i = 0;
             if (ws.N0 < 126) {
                 ws.N = ws.N0;
                 i = 2;


### PR DESCRIPTION
Even though there is no case where i does not get initialized since it can be at most 127, the compiler doesn't always know this. Avoid a maybe-unintialized warning for i.