### PR TITLE
disable logging on failed connect

### DIFF
--- a/easywsclient.cpp
+++ b/easywsclient.cpp
@@ -460,7 +460,7 @@ easywsclient::WebSocket::pointer from_url(const std::string& url, bool useMask, 
     //fprintf(stderr, "easywsclient: connecting: host=%s port=%d path=/%s\n", host, port, path);
     socket_t sockfd = hostname_connect(host, port);
     if (sockfd == INVALID_SOCKET) {
-        fprintf(stderr, "Unable to connect to %s:%d\n", host, port);
+        //fprintf(stderr, "Unable to connect to %s:%d\n", host, port);
         return NULL;
     }
     {


### PR DESCRIPTION
A failed connection is normal (more likely a connectivity issue than programming error) so the library should avoid logging.  A real app needs to handle connectivity issues and periodically retry connections, and this logging at every attempt wouldn't be too useful.