### PR TITLE
Fix build error of IPPROTO_TCP on android

### DIFF
--- a/easywsclient.cpp
+++ b/easywsclient.cpp
@@ -43,6 +43,7 @@
 #else
     #include <fcntl.h>
     #include <netdb.h>
+    #include <netinet/in.h>
     #include <netinet/tcp.h>
     #include <stdio.h>
     #include <stdlib.h>


### PR DESCRIPTION
I got the following error when build this lib by source on android:

```
easywsclient.cpp:522:24: error: use of undeclared identifier 'IPPROTO_TCP'
    setsockopt(sockfd, IPPROTO_TCP, TCP_NODELAY, (char*) &flag, sizeof(flag)); // Disable Nagle's algorithm
                       ^
1 error generated.
```

Add a header `#include <netinet/in.h>` fixed it.